### PR TITLE
May release

### DIFF
--- a/_whatsnew/2026-05-31.adoc
+++ b/_whatsnew/2026-05-31.adoc
@@ -1,0 +1,5 @@
+=== Support for AWS GovCloud (US) in NetApp Workload Factory
+
+NetApp Workload Factory supports AWS GovCloud (US) accounts. Using a GovCloud account, you can deploy and manage storage workloads in the AWS GovCloud (US) regions.
+
+// Use absolute links in these files

--- a/learn-about-vmware-workloads.adoc
+++ b/learn-about-vmware-workloads.adoc
@@ -61,6 +61,7 @@ The Well-architected tab provides automated daily analysis of your Amazon Elasti
 Automatic scans are performed using AWS APIs—no vSphere credentials are required. Findings are organized by configuration area, with each finding including status, severity levels, impacted resource details, and step-by-step remediation procedures. 
 
 link:view-evs-well-architected.html[Implement well-architected EVS configurations in Workload Factory].
+
 == Cost
 
 There is no cost for using Workload Factory for VMware.
@@ -77,6 +78,5 @@ Workload Factory is supported in all commercial regions where FSx for ONTAP is s
 The following AWS regions aren't supported:
  
 * China regions
-* GovCloud (US) regions
 * Secret Cloud
 * Top Secret Cloud

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -14,6 +14,10 @@ Learn what's new with the VMware migration advisor component of Workload Factory
 
 //tag::whats-new[]
 //tag::whats-new[]
+== 31 May 2026
+
+include::_whatsnew/2026-05-31.adoc[]
+
 == 09 March 2026
 
 include::_whatsnew/2026-03-09.adoc[]


### PR DESCRIPTION
This pull request updates documentation to announce and clarify support for AWS GovCloud (US) in NetApp Workload Factory. It adds a new "What's New" entry, updates region support details, and ensures users are informed about this expanded capability.

**Documentation updates for AWS GovCloud (US) support:**

* Added a new release note in `_whatsnew/2026-05-31.adoc` announcing support for AWS GovCloud (US) accounts in NetApp Workload Factory, allowing deployment and management of storage workloads in these regions.
* Updated `whats-new.adoc` to include the new entry for 31 May 2026, referencing the GovCloud support announcement.

**Clarifications and corrections in region support documentation:**

* Removed "GovCloud (US) regions" from the list of unsupported AWS regions in `learn-about-vmware-workloads.adoc`, reflecting the new support.
* Added a clarifying note in `learn-about-vmware-workloads.adoc` to inform users about the Well-Architected tab and its features, ensuring up-to-date guidance.